### PR TITLE
Centraliza configuración de base de datos en scripts de PDF

### DIFF
--- a/PDF7_Traspaso.py
+++ b/PDF7_Traspaso.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from reportlab.lib.pagesizes import letter, landscape
 from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Image, Paragraph, Spacer
 from reportlab.lib import colors
@@ -8,27 +8,18 @@ from reportlab.lib.enums import TA_CENTER
 import sys
 import os  # Importar el módulo os para manejar directorios
 
-from sqlalchemy import create_engine, text
 from openpyxl import load_workbook
 import win32com.client
 import os
 import sys
 from datetime import datetime
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
-DB_TABLE = 'CierreSucursales4'
-
+from db_config import DB_TABLE, get_engine
 
 def get_data_from_sql(departamento, ceco):
     """
     Obtiene los datos de la base de datos usando los parámetros departamento y ceco.
     """
-    SQLALCHEMY_DATABASE_URI = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
-    engine = create_engine(SQLALCHEMY_DATABASE_URI, echo=False)
+    engine = get_engine()
     
     # Modificamos la consulta para obtener los campos necesarios para el traspaso
     query = text(f"""

--- a/PDF_BAJA.py
+++ b/PDF_BAJA.py
@@ -1,23 +1,16 @@
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from openpyxl import load_workbook
 import win32com.client
 import os
 import sys
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
-DB_TABLE = 'CierreSucursales4'
+from db_config import DB_TABLE, get_engine
 
 
 def get_data_from_sql(departamento, ceco):
     """
     Obtiene los datos de la base de datos usando los parámetros departamento y ceco.
     """
-    SQLALCHEMY_DATABASE_URI = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
-    engine = create_engine(SQLALCHEMY_DATABASE_URI, echo=False)
+    engine = get_engine()
     
     # query = text(f"""
     # SELECT [Act. Fijo],[Tipo de Activo],[Denominacion del activo fijo], [Val. Cont.], 'NA' as Modelo, 'NA' as Serie, [Ceco] 

--- a/PDF_Recoleccion.py
+++ b/PDF_Recoleccion.py
@@ -1,23 +1,16 @@
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from openpyxl import load_workbook
 import win32com.client
 import os
 import sys
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
-DB_TABLE = 'CierreSucursales4'
+from db_config import DB_TABLE, get_engine
 
 
 def get_data_from_sql(departamento, ceco):
     """
     Obtiene los datos de la base de datos usando los parámetros departamento y ceco.
     """
-    SQLALCHEMY_DATABASE_URI = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
-    engine = create_engine(SQLALCHEMY_DATABASE_URI, echo=False)
+    engine = get_engine()
     
     # Consulta para obtener los datos de los activos
     query = text(f"""

--- a/PDF_Tecnico.py
+++ b/PDF_Tecnico.py
@@ -1,23 +1,16 @@
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
 from openpyxl import load_workbook
 import win32com.client
 import os
 import sys
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
-DB_TABLE = 'CierreSucursales4'
+from db_config import DB_TABLE, get_engine
 
 
 def get_data_from_sql(departamento, ceco):
     """
     Obtiene los datos de la base de datos usando los parámetros departamento y ceco.
     """
-    SQLALCHEMY_DATABASE_URI = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
-    engine = create_engine(SQLALCHEMY_DATABASE_URI, echo=False)
+    engine = get_engine()
     
     query = text(f"""
             

--- a/db_config.py
+++ b/db_config.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy import create_engine
+
+DB_SERVER = os.getenv('DB_SERVER', 'MPWPAS01')
+DB_NAME = os.getenv('DB_NAME', 'DBBI')
+DB_USER = os.getenv('DB_USER', 'AlertDBBI')
+DB_PASSWORD = os.getenv('DB_PASSWORD', 'P4$9')
+DB_TABLE = os.getenv('DB_TABLE', 'CierreSucursales4')
+
+def get_connection_url():
+    """Build the SQLAlchemy connection URL from environment variables."""
+    return (
+        f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?"
+        "driver=ODBC+Driver+17+for+SQL+Server"
+    )
+
+def get_engine(echo: bool = False):
+    """Create a SQLAlchemy engine using the configured connection URL."""
+    return create_engine(get_connection_url(), echo=echo)


### PR DESCRIPTION
## Resumen
- Añade módulo `db_config` con parámetros de conexión a base de datos y utilitario `get_engine`.
- Actualiza scripts de generación de PDF para usar `db_config` y evitar duplicar credenciales.

## Pruebas
- `python -m py_compile PDF7_Traspaso.py PDF_BAJA.py PDF_Recoleccion.py PDF_Tecnico.py db_config.py`


------
https://chatgpt.com/codex/tasks/task_e_689e9d38eaf883318bf64abd3a05fd91