### PR TITLE
Centralize configuration and secure credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_SERVER=your_db_server
+DB_NAME=your_db_name
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_TABLE=CierreSucursales4
+APP_SECRET_KEY=change_me
+ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/UploadExcel_Monse3GP.py
+++ b/UploadExcel_Monse3GP.py
@@ -15,23 +15,19 @@ from email.mime.text import MIMEText
 
 import smtplib
 import logging
+from config import get_config
 
 
 
-app = Flask(__name__) 
-app.secret_key = 'Te_llore_un_rio'  # Necesaria para las sesiones
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
+app = Flask(__name__)
+config = get_config()
+app.config.from_object(config)
+app.secret_key = config.SECRET_KEY
 
 UPLOAD_FOLDER = 'uploads'
 ALLOWED_EXTENSIONS = {'xlsx', 'xls'}
 
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.config['SQLALCHEMY_DATABASE_URI'] = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
@@ -70,8 +66,6 @@ EXPECTED_COLUMNS = [
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
-
-app.secret_key = 'Te_llore_un_rio'  # Necesario para manejar sesiones
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/UploadExcel_Monse3GR.py
+++ b/UploadExcel_Monse3GR.py
@@ -15,23 +15,19 @@ from email.mime.text import MIMEText
 
 import smtplib
 import logging
+from config import get_config
 
 
 
-app = Flask(__name__) 
-app.secret_key = 'Te_llore_un_rio'  # Necesaria para las sesiones
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
+app = Flask(__name__)
+config = get_config()
+app.config.from_object(config)
+app.secret_key = config.SECRET_KEY
 
 UPLOAD_FOLDER = 'uploads'
 ALLOWED_EXTENSIONS = {'xlsx', 'xls'}
 
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.config['SQLALCHEMY_DATABASE_URI'] = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
@@ -70,8 +66,6 @@ EXPECTED_COLUMNS = [
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
-
-app.secret_key = 'Te_llore_un_rio'  # Necesario para manejar sesiones
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/UploadExcel_Monse3Gq.py
+++ b/UploadExcel_Monse3Gq.py
@@ -15,23 +15,19 @@ from email.mime.text import MIMEText
 
 import smtplib
 import logging
+from config import get_config
 
 
 
-app = Flask(__name__) 
-app.secret_key = 'Te_llore_un_rio'  # Necesaria para las sesiones
-
-# Configuración de la base de datos
-DB_SERVER = 'MPWPAS01'
-DB_NAME = 'DBBI'
-DB_USER = 'AlertDBBI'
-DB_PASSWORD = 'P4$9'
+app = Flask(__name__)
+config = get_config()
+app.config.from_object(config)
+app.secret_key = config.SECRET_KEY
 
 UPLOAD_FOLDER = 'uploads'
 ALLOWED_EXTENSIONS = {'xlsx', 'xls'}
 
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.config['SQLALCHEMY_DATABASE_URI'] = f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?driver=ODBC+Driver+17+for+SQL+Server"
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 db = SQLAlchemy(app)
@@ -70,8 +66,6 @@ EXPECTED_COLUMNS = [
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
-
-app.secret_key = 'Te_llore_un_rio'  # Necesario para manejar sesiones
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/config.py
+++ b/config.py
@@ -1,0 +1,34 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Config:
+    """Base configuration loaded from environment variables."""
+
+    DB_SERVER: str = os.environ["DB_SERVER"]
+    DB_NAME: str = os.environ["DB_NAME"]
+    DB_USER: str = os.environ["DB_USER"]
+    DB_PASSWORD: str = os.environ["DB_PASSWORD"]
+    DB_TABLE: str = os.getenv("DB_TABLE", "CierreSucursales4")
+    SECRET_KEY: str = os.environ.get("APP_SECRET_KEY", "change_me")
+    SQLALCHEMY_DATABASE_URI: str = (
+        f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?"
+        "driver=ODBC+Driver+17+for+SQL+Server"
+    )
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+
+class ProductionConfig(Config):
+    DEBUG = False
+
+CONFIG_MAP = {
+    "development": DevelopmentConfig,
+    "production": ProductionConfig,
+}
+
+def get_config():
+    """Return the configuration class based on the ENV variable."""
+    env = os.environ.get("ENV", "development").lower()
+    return CONFIG_MAP.get(env, Config)

--- a/db_config.py
+++ b/db_config.py
@@ -1,18 +1,14 @@
-import os
 from sqlalchemy import create_engine
+from config import get_config
 
-DB_SERVER = os.getenv('DB_SERVER', 'MPWPAS01')
-DB_NAME = os.getenv('DB_NAME', 'DBBI')
-DB_USER = os.getenv('DB_USER', 'AlertDBBI')
-DB_PASSWORD = os.getenv('DB_PASSWORD', 'P4$9')
-DB_TABLE = os.getenv('DB_TABLE', 'CierreSucursales4')
+cfg = get_config()
+DB_TABLE = cfg.DB_TABLE
+
 
 def get_connection_url():
-    """Build the SQLAlchemy connection URL from environment variables."""
-    return (
-        f"mssql+pyodbc://{DB_USER}:{DB_PASSWORD}@{DB_SERVER}/{DB_NAME}?"
-        "driver=ODBC+Driver+17+for+SQL+Server"
-    )
+    """Build the SQLAlchemy connection URL from configuration."""
+    return cfg.SQLALCHEMY_DATABASE_URI
+
 
 def get_engine(echo: bool = False):
     """Create a SQLAlchemy engine using the configured connection URL."""


### PR DESCRIPTION
## Summary
- centralize settings in `config.py` with development/production classes
- drop hardcoded credentials and use environment-driven config in `db_config` and upload scripts
- provide `.env.example` and `.gitignore` to keep secrets out of version control

## Testing
- `python -m py_compile config.py db_config.py UploadExcel_Monse3GR.py UploadExcel_Monse3GP.py UploadExcel_Monse3Gq.py`


------
https://chatgpt.com/codex/tasks/task_e_689eadbe2830833199d12b9409da86a3