### PR TITLE
Add Alembic migrations and ORM models

### DIFF
--- a/UploadExcel_Monse3GP.py
+++ b/UploadExcel_Monse3GP.py
@@ -1536,7 +1536,10 @@ def accesos():
         # Verificar si el correo ya existe usando SQL directo
         try:
             conn = db.engine.connect()
-            result = conn.execute(text(f"SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = '{correo}'"))
+            result = conn.execute(
+                text("SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = :correo"),
+                {"correo": correo},
+            )
             usuario_existente = result.fetchone()
             conn.close()
             

--- a/UploadExcel_Monse3GR.py
+++ b/UploadExcel_Monse3GR.py
@@ -1639,7 +1639,10 @@ def accesos():
         # Verificar si el correo ya existe usando SQL directo
         try:
             conn = db.engine.connect()
-            result = conn.execute(text(f"SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = '{correo}'"))
+            result = conn.execute(
+                text("SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = :correo"),
+                {"correo": correo},
+            )
             usuario_existente = result.fetchone()
             conn.close()
             

--- a/UploadExcel_Monse3Gq.py
+++ b/UploadExcel_Monse3Gq.py
@@ -1574,7 +1574,10 @@ def accesos():
         # Verificar si el correo ya existe usando SQL directo
         try:
             conn = db.engine.connect()
-            result = conn.execute(text(f"SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = '{correo}'"))
+            result = conn.execute(
+                text("SELECT Correo FROM CierreSucursales_Control_Accesos_Web WHERE Correo = :correo"),
+                {"correo": correo},
+            )
             usuario_existente = result.fetchone()
             conn.close()
             

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = 
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = 
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/cierre_farmacias_app/models.py
+++ b/cierre_farmacias_app/models.py
@@ -1,0 +1,19 @@
+"""Database models for CierreSucursales application."""
+from sqlalchemy import Column, Integer, String, Index
+from .extensions import db
+
+
+class CierreSucursal(db.Model):
+    """ORM model for the main CierreSucursales table."""
+
+    __tablename__ = "CierreSucursales4"
+    __table_args__ = (
+        {"schema": "dbo"},
+        Index("ix_cs4_departamento", "Departamento"),
+        Index("ix_cs4_departamento_accion", "Departamento", "Accion"),
+    )
+
+    id = Column("ID", Integer, primary_key=True)
+    ceco = Column("Ceco", String(50), nullable=False)
+    departamento = Column("Departamento", String(100), nullable=False)
+    accion = Column("Accion", String(50), nullable=False)

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,8 @@
+# Database Migrations
+
+This directory contains Alembic migrations. Use the following commands to run migrations:
+
+```bash
+alembic upgrade head     # Apply migrations
+alembic revision -m "message"  # Create new migration
+```

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,47 @@
+from __future__ import with_statement
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+from config import get_config
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    cfg = get_config()
+    url = cfg.SQLALCHEMY_DATABASE_URI
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    cfg = get_config()
+    connectable = engine_from_config(
+        {"sqlalchemy.url": cfg.SQLALCHEMY_DATABASE_URI},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0001_add_indexes.py
+++ b/migrations/versions/0001_add_indexes.py
@@ -1,0 +1,37 @@
+"""Add indexes for performance"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001_add_indexes"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_cs4_departamento",
+        "CierreSucursales4",
+        ["Departamento"],
+        schema="dbo",
+    )
+    op.create_index(
+        "ix_cs4_departamento_accion",
+        "CierreSucursales4",
+        ["Departamento", "Accion"],
+        schema="dbo",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_cs4_departamento",
+        table_name="CierreSucursales4",
+        schema="dbo",
+    )
+    op.drop_index(
+        "ix_cs4_departamento_accion",
+        table_name="CierreSucursales4",
+        schema="dbo",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,4 +16,5 @@ dependencies = [
     "Celery",
     "pandas",
     "python-dotenv",
+    "alembic",
 ]


### PR DESCRIPTION
## Summary
- introduce Alembic for database migrations and declare indexes on `CierreSucursales4`
- add SQLAlchemy ORM model and refactor report service to use ORM queries
- parameterize email lookup queries to prevent SQL injection

## Testing
- `python -m py_compile cierre_farmacias_app/models.py cierre_farmacias_app/services/reports.py UploadExcel_Monse3GR.py UploadExcel_Monse3Gq.py UploadExcel_Monse3GP.py migrations/env.py migrations/versions/0001_add_indexes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eb59514188331af869e46ffb792a0