### PR TITLE
Add basic tests and CI pipelines with security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install .[dev]
+      - name: Run tests
+        run: pytest --cov=cierre_farmacias_app --cov-report=xml
+      - name: Run Bandit
+        run: bandit -r cierre_farmacias_app -ll --exit-zero
+      - name: Run Safety
+        run: safety check --full-report || true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+stages:
+  - test
+
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+cache:
+  paths:
+    - .cache/pip
+
+pytest:
+  stage: test
+  image: python:3.11
+  before_script:
+    - pip install .[dev]
+  script:
+    - pytest --cov=cierre_farmacias_app --cov-report=xml
+    - bandit -r cierre_farmacias_app -ll --exit-zero
+    - safety check --full-report || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,11 @@ dependencies = [
     "prometheus-flask-exporter",
     "sentry-sdk",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "bandit",
+    "safety",
+]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,35 @@
+import pytest
+from cierre_farmacias_app import create_app
+
+class TestConfig:
+    SECRET_KEY = "test"
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    CELERY_BROKER_URL = "memory://"
+    CELERY_RESULT_BACKEND = "cache+memory://"
+    LANGUAGES = ["es"]
+    BABEL_DEFAULT_LOCALE = "es"
+    LOG_LEVEL = "DEBUG"
+    SENTRY_DSN = None
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setattr("cierre_farmacias_app.__init__.get_config", lambda: TestConfig)
+    app = create_app()
+    app.config.update(TESTING=True)
+    yield app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_app_creation(app):
+    assert app.config["SECRET_KEY"] == "test"
+
+
+def test_root_redirects_to_login(client):
+    response = client.get("/")
+    assert response.status_code == 302
+    assert "/login" in response.headers.get("Location", "")


### PR DESCRIPTION
## Summary
- add optional dev dependencies
- include pytest unit tests
- configure GitHub Actions and GitLab CI to run tests, coverage, Bandit and Safety

## Testing
- `pytest -q` *(fails: No module named 'flask')*
- `pip install -e .[dev]` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689eb9acdd6483318fe9860e902e28b0