### PR TITLE
Add documentation and API specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Cierre de Farmacias
+
+Aplicación web para gestionar procesos de cierre de farmacias. Incluye autenticación, carga de archivos, generación de reportes y envío de notificaciones.
+
+## Contenido
+
+- [Instalación y despliegue](docs/installation_and_deployment.md)
+- [Documentación de API](docs/api/README.md)
+- [Manual de usuario](docs/user_manual.md)
+- [Guía de capacitación](docs/onboarding_guide.md)
+
+## Requisitos
+
+- Python 3.11+
+- Acceso a una base de datos SQL Server
+- Redis para tareas de Celery
+
+## Uso rápido
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+cp .env.example .env  # configurar variables
+python run.py
+```
+
+Ejecute las pruebas con:
+
+```bash
+pytest
+```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,15 @@
+# Documentación de la API
+
+El archivo [openapi.yaml](openapi.yaml) contiene la especificación OpenAPI de los endpoints disponibles.
+
+## Visualización
+
+Puedes visualizar la documentación utilizando [Swagger UI](https://swagger.io/tools/swagger-ui/) o [Redoc](https://redocly.com/):
+
+```bash
+npm install -g redoc-cli
+redoc-cli bundle docs/api/openapi.yaml
+```
+
+Esto generará un archivo `redoc-static.html` con la documentación.
+

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,123 @@
+openapi: 3.0.3
+info:
+  title: Cierre de Farmacias API
+  version: 1.0.0
+  description: API para gestionar cierres de farmacias.
+servers:
+  - url: http://localhost:5000
+paths:
+  /login:
+    get:
+      summary: Mostrar formulario de inicio de sesión
+      responses:
+        '200':
+          description: Formulario HTML
+    post:
+      summary: Autenticar usuario
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+              required:
+                - username
+                - password
+      responses:
+        '302':
+          description: Redirige al dashboard en caso de éxito
+        '401':
+          description: Credenciales inválidas
+  /logout:
+    get:
+      summary: Cerrar sesión del usuario
+      responses:
+        '302':
+          description: Redirige al formulario de login
+  /upload:
+    get:
+      summary: Formulario de carga de archivos
+      responses:
+        '200':
+          description: Formulario HTML
+    post:
+      summary: Procesar carga de archivos Excel
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                tipo_general:
+                  type: string
+                  enum: [Baja, Traspaso]
+              required:
+                - file
+                - tipo_general
+      responses:
+        '200':
+          description: Resultado del procesamiento
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+  /data:
+    get:
+      summary: Obtener datos procesados
+      responses:
+        '200':
+          description: Datos en formato JSON
+          content:
+            application/json: {}
+  /summary:
+    get:
+      summary: Obtener resumen de datos
+      responses:
+        '200':
+          description: Resumen en formato JSON
+          content:
+            application/json: {}
+  /send_notifications:
+    post:
+      summary: Enviar notificaciones por correo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ceco:
+                  type: string
+                departamento:
+                  type: string
+              required:
+                - ceco
+                - departamento
+      responses:
+        '200':
+          description: Resultado del envío
+          content:
+            application/json: {}
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: session
+security:
+  - cookieAuth: []

--- a/docs/installation_and_deployment.md
+++ b/docs/installation_and_deployment.md
@@ -1,0 +1,63 @@
+# Guía de instalación y despliegue
+
+## Prerrequisitos
+
+- Python 3.11+
+- [Redis](https://redis.io/) para tareas de Celery
+- Base de datos SQL Server accesible
+
+## Instalación
+
+1. Clonar el repositorio:
+   ```bash
+   git clone <repo>
+   cd cierre_farmacias
+   ```
+2. Crear y activar un entorno virtual:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Instalar dependencias:
+   ```bash
+   pip install -e .
+   ```
+4. Configurar variables de entorno en un archivo `.env` (ver `.env.example`):
+
+| Variable | Descripción |
+| --- | --- |
+| `DB_SERVER` | Host del servidor SQL Server |
+| `DB_NAME` | Nombre de la base de datos |
+| `DB_USER` | Usuario de la base de datos |
+| `DB_PASSWORD` | Contraseña del usuario |
+| `APP_SECRET_KEY` | Clave secreta de Flask |
+| `MAIL_SERVER` | Servidor SMTP |
+| `MAIL_PORT` | Puerto SMTP |
+| `MAIL_USERNAME` | Usuario SMTP |
+| `MAIL_PASSWORD` | Contraseña SMTP |
+| `CELERY_BROKER_URL` | URL de Redis para Celery |
+| `CELERY_RESULT_BACKEND` | Backend de resultados de Celery |
+
+5. Inicializar la base de datos si es necesario usando Alembic:
+   ```bash
+   alembic upgrade head
+   ```
+
+## Ejecución local
+
+```bash
+python run.py
+```
+La aplicación se iniciará en `http://localhost:5000`.
+
+## Despliegue
+
+1. Configurar variables de entorno en el servidor.
+2. Instalar dependencias en modo producción: `pip install .`
+3. Ejecutar migraciones de base de datos.
+4. Lanzar la aplicación con un servidor WSGI, por ejemplo:
+   ```bash
+   gunicorn 'cierre_farmacias_app:create_app()'
+   ```
+5. Configurar un servicio supervisor o sistema similar para mantener el proceso.
+

--- a/docs/onboarding_guide.md
+++ b/docs/onboarding_guide.md
@@ -1,0 +1,36 @@
+# Guía de capacitación para nuevos integrantes
+
+Bienvenido al proyecto **Cierre de Farmacias**. Esta guía te ayudará a comenzar rápidamente.
+
+## 1. Configuración del entorno
+- Sigue la [guía de instalación](installation_and_deployment.md) para preparar tu entorno.
+- Crea un archivo `.env` con las variables necesarias.
+
+## 2. Estructura del proyecto
+- `cierre_farmacias_app/`: código principal de la aplicación.
+- `templates/` y `static/`: recursos web.
+- `tests/`: pruebas automatizadas.
+- `docs/`: documentación.
+
+## 3. Flujo de trabajo
+1. Crea una rama a partir de `main` para tus cambios.
+2. Instala dependencias de desarrollo:
+   ```bash
+   pip install -e .[dev]
+   ```
+3. Ejecuta las pruebas antes de hacer commit:
+   ```bash
+   pytest
+   ```
+4. Envía tus cambios mediante un Pull Request.
+
+## 4. Estándares de código
+- Sigue las convenciones de [PEP 8](https://peps.python.org/pep-0008/).
+- Añade pruebas y documentación para nuevas funcionalidades.
+
+## 5. Recursos adicionales
+- [Documentación de Flask](https://flask.palletsprojects.com/)
+- [SQLAlchemy](https://www.sqlalchemy.org/)
+- [Celery](https://docs.celeryq.dev/)
+
+¡Bienvenido al equipo!

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,0 +1,28 @@
+# Manual de usuario
+
+## Inicio de sesión
+1. Accede a `http://localhost:5000/login`.
+2. Ingresa tu usuario y contraseña.
+3. Si las credenciales son correctas serás redirigido al **dashboard**.
+
+## Carga de archivos
+1. Desde el dashboard selecciona la opción **Cargar archivo**.
+2. Selecciona el archivo Excel y el **Tipo General** correspondiente.
+3. Envía el formulario. El sistema procesará la información y enviará correos de notificación.
+
+## Reportes
+- `/data`: Devuelve la información procesada en formato JSON.
+- `/summary`: Muestra un resumen de los datos.
+
+## Notificaciones manuales
+1. Envía una petición `POST` a `/send_notifications` con un cuerpo JSON:
+   ```json
+   {
+     "ceco": "12345",
+     "departamento": "Ventas"
+   }
+   ```
+2. El sistema devolverá el resultado del envío de correos.
+
+## Cierre de sesión
+- Utiliza el enlace **Logout** para cerrar la sesión de forma segura.


### PR DESCRIPTION
## Summary
- Add comprehensive README with project overview
- Provide installation and deployment guide
- Document API endpoints via OpenAPI and usage instructions
- Include user manual and onboarding guide for new contributors

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_689ebc9af1988331a44e887cd928c1ba