### PR TITLE
Restrict package discovery for editable installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ dev = [
     "bandit",
     "safety",
 ]
+
+[tool.setuptools]
+packages = ["cierre_farmacias_app"]
+py-modules = []


### PR DESCRIPTION
## Summary
- limit setuptools package discovery to the main `cierre_farmacias_app` package
- disable automatic module detection for cleaner builds

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `PYTHONPATH=. pytest tests/test_app.py::test_app_creation -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689ec13c6e808331b187501bd397a174