### PR TITLE
Enforce mandatory DB config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ set FLASK_DEBUG=1 && start_app.bat
 python app.py
 ```
 
+Las siguientes variables de entorno son **obligatorias** (no tienen valores por defecto) y la aplicación se detendrá si falta alguna:
+
+- `DB_SERVER`
+- `DB_NAME`
+- `DB_USER`
+- `DB_PASSWORD`
+- `APP_SECRET_KEY`
+
 La app toma variables de entorno opcionales:
 - `APP_HOST` (default `0.0.0.0`)
 - `APP_PORT` (default `5020`)
@@ -57,7 +65,7 @@ $env:APP_HOST="10.30.45.88"; $env:APP_PORT="5020"; python app.py
 El archivo `app.py` carga automáticamente un `.env` si está presente (usando `python-dotenv`).
 
 ## Notas de Seguridad
-Configurar credenciales y secretos en variables de entorno o archivo `.env` (no versionado):
+Configurar credenciales y secretos en variables de entorno o archivo `.env` (no versionado). Estas variables son obligatorias y no tienen valores por defecto:
 ```
 DB_SERVER=MPWPAS01
 DB_NAME=DBBI

--- a/UploadExcel_GR.py
+++ b/UploadExcel_GR.py
@@ -25,19 +25,19 @@ import csv
 import secrets
 import string
 
-REQUIRED_ENV_VARS = ['DB_SERVER','DB_NAME','DB_USER','APP_SECRET_KEY']
+REQUIRED_ENV_VARS = ['DB_SERVER', 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'APP_SECRET_KEY']
 missing = [v for v in REQUIRED_ENV_VARS if not os.getenv(v)]
 if missing:
-	print(f"[WARN] Variables de entorno faltantes: {', '.join(missing)}. Usando defaults inseguros donde aplique.")
+        raise RuntimeError(f"Faltan variables de entorno obligatorias: {', '.join(missing)}")
 
 app = Flask(__name__)
-app.secret_key = os.getenv('APP_SECRET_KEY', 'change_me_dev')  # Necesaria para las sesiones
+app.secret_key = os.getenv('APP_SECRET_KEY')  # Necesaria para las sesiones
 
 # Configuración de la base de datos vía variables de entorno
-DB_SERVER = os.getenv('DB_SERVER', 'MPWPAS01')
-DB_NAME = os.getenv('DB_NAME', 'DBBI')
-DB_USER = os.getenv('DB_USER', 'AlertDBBI')
-DB_PASSWORD = os.getenv('DB_PASSWORD', '')  # Evitar dejar password real por defecto
+DB_SERVER = os.getenv('DB_SERVER')
+DB_NAME = os.getenv('DB_NAME')
+DB_USER = os.getenv('DB_USER')
+DB_PASSWORD = os.getenv('DB_PASSWORD')
 
 UPLOAD_FOLDER = 'uploads'
 ALLOWED_EXTENSIONS = {'xlsx', 'xls'}


### PR DESCRIPTION
## Summary
- Raise an error when required DB environment variables are missing
- Document mandatory variables in README with no defaults

## Testing
- `python -m py_compile UploadExcel_GR.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1849d9a6483318bb4d2439195a903